### PR TITLE
fix #9 - now we only need to require zss7client or zss/service

### DIFF
--- a/lib/zss/client.rb
+++ b/lib/zss/client.rb
@@ -1,3 +1,4 @@
+require_relative '../zss'
 require_relative 'socket'
 
 module ZSS

--- a/lib/zss/service.rb
+++ b/lib/zss/service.rb
@@ -1,4 +1,5 @@
 require 'em-zeromq'
+require_relative '../zss'
 require_relative 'router'
 require_relative 'message/smi'
 


### PR DESCRIPTION
This way we avoid to require zss before.
